### PR TITLE
feat-disableCustomColor

### DIFF
--- a/src/editor-styles.css
+++ b/src/editor-styles.css
@@ -3,7 +3,7 @@
 	flex-direction: row;
 	flex-wrap: nowrap;
 	justify-content: flex-start;
-	align-items: flex-start;
+	align-items: flex-end;
 }
 
 .color-selector-field {
@@ -33,4 +33,8 @@
 
 .color-selector-label {
 	flex-basis: 100%;
+}
+
+.color-selector-wrapper .umb-color-swatches button:first-child {
+	margin-left: 0;
 }

--- a/src/editor-view.html
+++ b/src/editor-view.html
@@ -1,13 +1,16 @@
 <div class="color-selector-wrapper" ng-controller="ColorSelectorController">
 	
 	<div class="color-selector-choice">
-		<div class="color-selector-label"><localize key="color_inputColor">Input a CSS color</localize></div>
-		<input placeholder="ff8000" ng-change="didTypeManualColor()" name="color-selector-value" autocomplete="off" ng-model="model.value" type="text" value="{{model.value}}" class="color-selector-field" />
+		<div class="color-selector-label" ng-if="model.config.disableCustomColor != 1"><localize key="color_inputColor">Input a CSS color</localize></div>
+		<input placeholder="ff8000" ng-readonly="model.config.disableCustomColor == 1 ? 'checked' : ''" ng-change="didTypeManualColor()" name="color-selector-value" autocomplete="off" ng-model="model.value" type="text" value="{{model.value}}" class="color-selector-field" />
 		<div class="color-selector-preview" hex-bg-color="{{model.value}}"></div>
 	</div>
 	
 	<div class="color-selector-defaults color-selector-choice">
-		<div class="color-selector-label"><localize key="color_choosePreset">- or choose a preset:</localize></div>
+		<div class="color-selector-label">
+			<localize ng-if="model.config.disableCustomColor == 1" key="color_choosePresetAlt">Choose a preset:</localize>
+			<localize ng-if="model.config.disableCustomColor != 1" key="color_choosePreset">- or choose a preset:</localize>
+		</div>
 		<umb-color-swatches
 			size="s"
 			colors="colors"

--- a/src/lang/da-DK.xml
+++ b/src/lang/da-DK.xml
@@ -7,5 +7,6 @@
 	<area alias="color">
 		<key alias="inputColor">Indtast en CSS hex farve</key>
 		<key alias="choosePreset">- eller vælg et preset:</key>
+		<key alias="choosePresetAlt">Vælg et preset:</key>
 	</area>
 </language>

--- a/src/lang/en-GB.xml
+++ b/src/lang/en-GB.xml
@@ -7,5 +7,6 @@
 	<area alias="color">
 		<key alias="inputColor">Input a CSS hex colour</key>
 		<key alias="choosePreset">- or choose a preset:</key>
+		<key alias="choosePresetAlt">Choose a preset:</key>
 	</area>
 </language>

--- a/src/lang/en-US.xml
+++ b/src/lang/en-US.xml
@@ -7,5 +7,6 @@
 	<area alias="color">
 		<key alias="inputColor">Input a CSS hex color</key>
 		<key alias="choosePreset">- or choose a preset:</key>
+		<key alias="choosePresetAlt">Choose a preset:</key>
 	</area>
 </language>

--- a/src/manifest.xml
+++ b/src/manifest.xml
@@ -11,6 +11,12 @@
 		</editor>
 		<prevalues>
 			<field>
+				<label>Disable custom color</label>
+				<key>disableCustomColor</key>
+				<description>Disable the ability to enter a custom hex color</description>
+				<view>boolean</view>
+			</field>
+			<field>
 				<label>Preset 1</label>
 				<key>preset1</key>
 				<description>You can add 5 preset colors</description>


### PR DESCRIPTION
Allowing to disable the custom color input.
Actually I just set the input field to readonly, when configuring the property editor :)